### PR TITLE
Replaced all license headers with unified layout

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -1,10 +1,11 @@
-# Copyright 2013, SUSE LLC
+#
+# Copyright 2013-2014, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 barclamp:
   name: hyperv
   display: Hyper-V


### PR DESCRIPTION
To get changes from https://github.com/SUSE-Cloud/barclamp-hyperv-compute/pull/2 into the right repository.
