### PR TITLE
Setting Nova, Neutron and Msiscsi services to automatic (bnc#888497)

### DIFF
--- a/chef/cookbooks/hyperv/recipes/register_services.rb
+++ b/chef/cookbooks/hyperv/recipes/register_services.rb
@@ -9,6 +9,7 @@ powershell "register_services" do
       New-Service -name "#{node[:service][:nova][:name]}" -binaryPathName "`"#{node[:openstack][:bin]}\\#{node[:service][:file]}`" nova-compute `"#{node[:openstack][:nova][:installed]}`" --config-file `"#{node[:openstack][:config]}\\nova.conf`"" -displayName "#{node[:service][:nova][:displayname]}" -description "#{node[:service][:nova][:description]}" -startupType Automatic
       # -Credential $credentials
       Start-Service "#{node[:service][:nova][:name]}"
+      Set-Service -Name "#{node[:service][:nova][:name]}" -StartupType Automatic
     }
     if (-not (Get-Service "#{node[:service][:neutron][:name]}" -ErrorAction SilentlyContinue))
     {
@@ -17,7 +18,10 @@ powershell "register_services" do
       New-Service -name "#{node[:service][:neutron][:name]}" -binaryPathName "`"#{node[:openstack][:bin]}\\#{node[:service][:file]}`" neutron-hyperv-agent `"#{node[:openstack][:neutron][:installed]}`" --config-file `"#{node[:openstack][:config]}\\neutron_hyperv_agent.conf`"" -displayName "#{node[:service][:neutron][:displayname]}" -description "#{node[:service][:neutron][:description]}" -startupType Automatic
       # -Credential $credentials
       Start-Service "#{node[:service][:neutron][:name]}"
+      Set-Service -Name "#{node[:service][:neutron][:name]}" -StartupType Automatic
     }
+    Start-Service -Name MSiSCSI
+    Set-Service -Name MSiSCSI -StartupType Automatic
   EOH
 end
 


### PR DESCRIPTION
Setting Nova, Neutron and MSiSCSI services to automatic ensures they
start when the system boots. Having the MSiSCSI service started and set
to Automatic is needed to be able to attach iSCSI devices as per http://docs.openstack.org/trunk/config-reference/content/hyper-v-virtualization-platform.html
Also it's related to https://bugzilla.suse.com/show_bug.cgi?id=888497 and it worked, tested twice.
