### PR TITLE
Fixing HA cookbook for windows instances (bnc#901309)

### DIFF
--- a/chef/cookbooks/hyperv/recipes/config.rb
+++ b/chef/cookbooks/hyperv/recipes/config.rb
@@ -19,7 +19,7 @@ glance_servers = search(:node, "roles:glance-server")
 if glance_servers.length > 0
   glance_server = glance_servers[0]
   glance_server = node if glance_server.name == node.name
-  glance_server_host = glance_server[:fqdn]
+  glance_server_host = CrowbarHelper.get_host_for_admin_url(glance_server, (glance_server[:glance][:ha][:enabled] rescue false))
   glance_server_port = glance_server[:glance][:api][:bind_port]
   glance_server_protocol = glance_server[:glance][:api][:protocol]
   glance_server_insecure = glance_server_protocol == 'https' && glance_server[:glance][:ssl][:insecure]
@@ -58,7 +58,7 @@ if neutron_servers.length > 0
   neutron_server = neutron_servers[0]
   neutron_server = node if neutron_server.name == node.name
   neutron_protocol = neutron_server[:neutron][:api][:protocol]
-  neutron_server_host = neutron_server[:fqdn]
+  neutron_server_host = CrowbarHelper.get_host_for_admin_url(neutron_server, (neutron_server[:neutron][:ha][:server][:enabled] rescue false))
   neutron_server_port = neutron_server[:neutron][:api][:service_port]
   neutron_insecure = neutron_protocol == 'https' && neutron_server[:neutron][:ssl][:insecure]
   neutron_service_user = neutron_server[:neutron][:service_user]


### PR DESCRIPTION
This fix is intended to fix the config that points to the first cluster
member instead of the cluster VIP.
