### PR TITLE
Add a do_all recipe that includes the other recipes in the right order

### DIFF
--- a/chef/cookbooks/hyperv/recipes/do_all.rb
+++ b/chef/cookbooks/hyperv/recipes/do_all.rb
@@ -1,0 +1,10 @@
+raise if not node[:platform] == 'windows'
+
+include_recipe "hyperv::windows_features"
+include_recipe "hyperv::setup_networking"
+include_recipe "hyperv::7zip"
+include_recipe "hyperv::python"
+include_recipe "hyperv::python_archive"
+include_recipe "hyperv::openstack_install"
+include_recipe "hyperv::config"
+include_recipe "hyperv::register_services"


### PR DESCRIPTION
Right now, the nova barclamp has to know the recipes here, and in which
order they are needed. This is a bit painful, and we can maintain this
here instead.