### PR TITLE
Installing all dependencies for windows features (bnc#887944)

### DIFF
--- a/chef/cookbooks/hyperv/attributes/default.rb
+++ b/chef/cookbooks/hyperv/attributes/default.rb
@@ -2,11 +2,31 @@
 # Windows features required:
 #
 
-default[:features_list][:hyperv] = ["Microsoft-Hyper-V", "Microsoft-Hyper-V-Management-PowerShell"]
-default[:features_list][:management] = ["Remote-Desktop-Services"]
-default[:features_list][:iscsi_target] = ["File-Services", "CoreFileServer"]
+default[:features_list][:hyperv] = {
+  "Microsoft-Hyper-V" => {
+    "restart" => false
+  },
+  "Microsoft-Hyper-V-Management-PowerShell" => {
+    "restart" => true
+  }
+}
 
-default[:features_list][:windows] = default[:features_list][:management] + default[:features_list][:hyperv] + default[:features_list][:iscsi_target]
+default[:features_list][:management] = {
+  "Remote-Desktop-Services" => {
+    "restart" => false
+  }
+}
+
+default[:features_list][:iscsi_target] = {
+  "File-Services" => {
+    "restart" => false
+  },
+  "CoreFileServer" => {
+    "restart" => false
+  }
+}
+
+default[:features_list][:windows] = default[:features_list][:management].merge(default[:features_list][:hyperv].merge(default[:features_list][:iscsi_target]))
 
 default[:sevenzip][:location] = "#{Chef::Config[:file_cache_path]}/"
 default[:sevenzip][:file] = "7z922-x64.msi"

--- a/chef/cookbooks/hyperv/recipes/windows_features.rb
+++ b/chef/cookbooks/hyperv/recipes/windows_features.rb
@@ -15,6 +15,7 @@ if !node[:windows_features_installed]
   node[:features_list][:windows].each do |feature_list|
     windows_feature feature_list do
       action :install
+      all true
     end
   end
 

--- a/chef/cookbooks/hyperv/recipes/windows_features.rb
+++ b/chef/cookbooks/hyperv/recipes/windows_features.rb
@@ -3,6 +3,11 @@ raise if not node[:platform] == 'windows'
 node.default[:windows][:allow_pending_reboots] = false
 
 if node[:target_platform] !~ /^hyperv/
+  unless node[:windows_features_installed].is_a? Array
+    node.set[:windows_features_installed] = []
+    node.save
+  end
+
   node[:features_list][:windows].each do |feature_name, feature_attrs|
     next if node[:windows_features_installed].include? feature_name
 
@@ -14,10 +19,6 @@ if node[:target_platform] !~ /^hyperv/
 
     ruby_block 'set_windows_features_install_flag' do
       block do
-        unless node[:windows_features_installed].is_a? Array
-          node.set[:windows_features_installed] = []
-        end
-
         node.set[:windows_features_installed].push feature_name
         node.save
       end

--- a/chef/cookbooks/windows/providers/feature_dism.rb
+++ b/chef/cookbooks/windows/providers/feature_dism.rb
@@ -23,13 +23,15 @@ include Chef::Mixin::ShellOut
 include Windows::Helper
 
 def install_feature(name)
-  # return code 3010 is valid, it indicates a reboot is required
-  shell_out!("#{dism} /online /enable-feature /featurename:#{@new_resource.feature_name} /norestart", {:returns => [0,42,127,3010]})
+  addsource = @new_resource.source ? "/LimitAccess /Source:\"#{@new_resource.source}\"" : ""
+  addall = @new_resource.all ? "/All" : ""
+  restart = @new_resource.restart ? "" : "/norestart"
+  shell_out!("#{dism} /online /enable-feature /featurename:#{@new_resource.feature_name} #{restart} #{addsource} #{addall}", {:returns => [0,42,127,3010]})
 end
 
 def remove_feature(name)
-  # return code 3010 is valid, it indicates a reboot is required
-  shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /norestart", {:returns => [0,42,127,3010]})
+  restart = @new_resource.restart ? "" : "/norestart"
+  shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} #{restart}", {:returns => [0,42,127,3010]})
 end
 
 def installed?

--- a/chef/cookbooks/windows/providers/feature_dism.rb
+++ b/chef/cookbooks/windows/providers/feature_dism.rb
@@ -25,12 +25,12 @@ include Windows::Helper
 def install_feature(name)
   addsource = @new_resource.source ? "/LimitAccess /Source:\"#{@new_resource.source}\"" : ""
   addall = @new_resource.all ? "/All" : ""
-  restart = @new_resource.restart ? "" : "/norestart"
+  restart = @new_resource.restart ? "/quiet" : "/norestart"
   shell_out!("#{dism} /online /enable-feature /featurename:#{@new_resource.feature_name} #{restart} #{addsource} #{addall}", {:returns => [0,42,127,3010]})
 end
 
 def remove_feature(name)
-  restart = @new_resource.restart ? "" : "/norestart"
+  restart = @new_resource.restart ? "/quiet" : "/norestart"
   shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} #{restart}", {:returns => [0,42,127,3010]})
 end
 

--- a/chef/cookbooks/windows/resources/feature.rb
+++ b/chef/cookbooks/windows/resources/feature.rb
@@ -23,6 +23,9 @@ include Windows::Helper
 actions :install, :remove
 
 attribute :feature_name, :kind_of => String, :name_attribute => true
+attribute :source, :kind_of => String
+attribute :all, :kind_of => [ TrueClass, FalseClass ], :default => false
+attribute :restart, :kind_of => [TrueClass, FalseClass], :default => false
 
 def initialize(name, run_context=nil)
   super


### PR DESCRIPTION
This fix adds the flag to install all dependencies of a windows feature.
In this case the feature Microsoft-Hyper-V-Management-PowerShell failed
to be enabled with the Error 50 because the dependencies were missing.