### PR TITLE
Install missing dependency for Hyperv-V Manageement Console (bnc#887944)

### DIFF
--- a/chef/cookbooks/hyperv/attributes/default.rb
+++ b/chef/cookbooks/hyperv/attributes/default.rb
@@ -6,6 +6,9 @@ default[:features_list][:hyperv] = {
   "Microsoft-Hyper-V" => {
     "restart" => false
   },
+  "RSAT-Hyper-V-Tools-Feature" => {
+    "restart" => false
+  },
   "Microsoft-Hyper-V-Management-PowerShell" => {
     "restart" => true
   }

--- a/chef/cookbooks/hyperv/attributes/default.rb
+++ b/chef/cookbooks/hyperv/attributes/default.rb
@@ -9,6 +9,9 @@ default[:features_list][:hyperv] = {
   "RSAT-Hyper-V-Tools-Feature" => {
     "restart" => false
   },
+  "Microsoft-Hyper-V-Management-Clients" => {
+    "restart" => false
+  },
   "Microsoft-Hyper-V-Management-PowerShell" => {
     "restart" => true
   }


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=887944
